### PR TITLE
hide streamlit defaults

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -171,6 +171,7 @@ st.set_page_config(page_title=os.environ['DOMAIN'])
 hide_streamlit_style = """
             <style>
             #MainMenu {visibility: hidden;}
+            header {visibility: hidden;}
             </style>
             """
 st.markdown(hide_streamlit_style, unsafe_allow_html=True) 


### PR DESCRIPTION
# Update
* just hide orange/red bar at top to help hide the fact this app was built with streamlit